### PR TITLE
MC-1 - Removed jobs

### DIFF
--- a/dispatcher/src/main.rs
+++ b/dispatcher/src/main.rs
@@ -12,7 +12,6 @@ use crate::routes::{client_routes, info_routes};
 
 pub struct ServerState {
     ip_range: Mutex<Ipv4AddrRange>,
-    outstanding_scout_jobs: Mutex<Vec<ScoutJob>>,
     valid_ips: Mutex<VecDeque<Ipv4Addr>>
 }
 
@@ -33,7 +32,6 @@ fn rocket() -> _ {
         .manage(ServerState {
             ip_range: Mutex::new(Ipv4AddrRange::new("1.0.0.0".parse().unwrap(),
             "255.255.255.255".parse().unwrap())),
-            outstanding_scout_jobs: Mutex::new(Vec::new()),
             valid_ips: Mutex::new(VecDeque::new())
         })
 }

--- a/scout/src/main.rs
+++ b/scout/src/main.rs
@@ -101,7 +101,6 @@ fn main() -> Result<()> {
         handle.join().expect("sender thread panic!");
 
         println!("Finished job #{}", job_id);
-        confirm_job(job_id);
 
         // Lock ip vec mutex
         let mut valid_ips = valid_ips_mtx.lock().unwrap();
@@ -120,12 +119,6 @@ fn main() -> Result<()> {
 
     receiver_handle.join().expect("receiver thread panic!");
     Ok(())
-}
-
-fn confirm_job(id: u32) -> bool{
-    let client = reqwest::blocking::Client::new();
-    let url = format!("{}/scout/job/{}", config::get_dispatcher_base(), id);
-    client.post(url).send().is_ok()
 }
 
 fn upload_ips(ips: &Vec<Ipv4Addr>) -> bool {


### PR DESCRIPTION
Jobs don't really make sense anymore with new architecture. Removed them completely.

Scout now simply asks for a chunk of IP and uploads results whenever asking for a new chunk. Resulting IPs may not come from the previous chunk as replies from servers are async.