### PR TITLE
MC-3 - Add sanity check to detect rate limiting

### DIFF
--- a/scout/src/packet_handler.rs
+++ b/scout/src/packet_handler.rs
@@ -78,10 +78,22 @@ pub fn validate_response(packet: &[u8], port: u16) -> Option<(Ipv4Addr, bool)> {
     };
     if tcp.get_source() != port { return None; }  // Wrong port
 
-    // println!("{}:{} --> {}:{}",
-    //         ipv4.get_source(), tcp.get_source(),
-    //         ipv4.get_destination(), tcp.get_destination());
-
     let is_syn_ack = (tcp.get_flags() & TcpFlags::SYN) != 0 && (tcp.get_flags() & TcpFlags::ACK) != 0;
     Some((ipv4.get_source(), is_syn_ack))
+}
+
+pub fn validate_sanity_reply(packet: &[u8]) -> bool {
+    let ethernet = match EthernetPacket::new(packet) {
+        Some(x) => x,
+        None => return false
+    };
+
+    let ipv4 = match Ipv4Packet::new(ethernet.payload()) {
+        Some(x) => x,
+        None => return false
+    };
+
+    if ipv4.get_source() != Ipv4Addr::new(1, 1, 1, 1) { return false; }
+
+    true
 }

--- a/scout/src/threads.rs
+++ b/scout/src/threads.rs
@@ -32,19 +32,19 @@ pub fn receiver_thread(iface: &NetworkInterface, valid_ips_mtx: &Mutex<Vec<Ipv4A
         read_timeout: Option::from(Duration::from_secs(1)),
         ..Default::default()
     };
-    let (_, mut rx) = match pnet::datalink::channel(iface, pnet_config) {
+    let (mut tx, mut rx) = match pnet::datalink::channel(iface, pnet_config) {
         Ok(Channel::Ethernet(tx, rx)) => (tx, rx),
         Ok(_) => panic!("Wrong chanel type"),
         Err(e) => panic!("Error creating channel: {}", e)
     };
 
     // // Get packets until signal to stop received. Check for signal after 5s w/o packet
-    // let mut packet_count: u32 = 0;
-    // let mut time_waited: u64 = 0;
 
     // Get packets, when stop signal set to true, receive until no packets during timeout time period
     let max_no_packet_period = config::get_receive_timeout();
     let mut last_packet_time = SystemTime::now();
+    let mut awaiting_sanity = false;
+    let mut sanity_cnt = 0;
 
     let mut valid_ips = valid_ips_mtx.lock().unwrap();
 
@@ -67,12 +67,15 @@ pub fn receiver_thread(iface: &NetworkInterface, valid_ips_mtx: &Mutex<Vec<Ipv4A
 
         match rx.next() {
             Ok(packet) => {
+                if awaiting_sanity && validate_sanity_reply(packet) {
+                    // This was the reply to the sanity packet, don't analyze it further
+                    awaiting_sanity = false;
+                    continue;
+                }
+
                 if let Some((ip, syn_ack)) = validate_response(packet, 25565) {
                     // Response from server
 
-                    // packet_count += 1;
-                    // print!("\rResponses: {}", packet_count);
-                    // println!("Response from: {}", ip);
                     last_packet_time = SystemTime::now();
                     if syn_ack {
                         // Valid response packet
@@ -89,7 +92,25 @@ pub fn receiver_thread(iface: &NetworkInterface, valid_ips_mtx: &Mutex<Vec<Ipv4A
             _ => {
                 // No packets received
                 if !stop_signal.load(Ordering::Relaxed) {
-                    // Can't stop yet
+                    // Can't stop yet, check if no packets received due to rate limiting
+                    // Send sanity SYN to 1.1.1.1 (Cloudflare) and try to get an answer
+                    // If no answer, fair bet to assume rate limit, sleep for longer
+
+                    if awaiting_sanity && sanity_cnt < 5 {  // TODO Move 5 to config
+                        // Already sent out sanity packet, no reply, wait for longer
+                        sanity_cnt += 1;  // One more timeout awaiting sanity reply
+                        println!("No sanity reply, sleeping for {} secs...", 2);
+                        sleep(Duration::from_secs(2));  // TODO Move to config file
+                        continue;
+                    }
+
+                    // No answer or sent sanity packet too long ago, (re)send sanity packet
+                    println!("No answer in a while, sending sanity packet");
+                    tx.build_and_send(1, 66, &mut |packet: &mut [u8]| {
+                        generate_syn_packet(iface, &Ipv4Addr::new(1, 1, 1, 1), 80, packet);
+                    });
+                    sanity_cnt = 0;
+                    awaiting_sanity = true;
                     continue;
                 }
 


### PR DESCRIPTION
When no packets received for a while, send sanity SYN packet to known host (`1.1.1.1)` to detect if we are being rate limited. If we receive an answer from Cloudflare, we know we are not being rate limited, but simply don't have answers from the hosts we are sending to.


Cannot seem to get throttled anymore due to IP randomization, keep changes in branch, but don’t implemented yet due to lack of testing