### PR TITLE
MC-10 Transfer server response from client to dispatcher

### DIFF
--- a/client/src/checker.rs
+++ b/client/src/checker.rs
@@ -2,7 +2,6 @@ use std::error::Error;
 use std::fmt::{Display, Formatter};
 use std::net::{IpAddr, Ipv4Addr, SocketAddr, TcpStream};
 use std::time::Duration;
-use serde_json::Value;
 use crate::mc_packet::{MCPacket, PacketParseError};
 
 #[derive(Debug)]
@@ -16,7 +15,7 @@ impl Display for InvalidServerError {
 
 impl Error for InvalidServerError {}
 
-pub fn validate_server(addr: Ipv4Addr) -> Result<Value, InvalidServerError> {
+pub fn validate_server(addr: Ipv4Addr) -> Result<String, InvalidServerError> {
     let socket_addr = SocketAddr::new(IpAddr::V4(addr), 25565);
     let mut stream = TcpStream::connect_timeout(&socket_addr, Duration::from_secs(crate::TCP_TIMEOUT_SECS))
         .map_err(|_| InvalidServerError("Timed out connecting to host".into()))?;
@@ -33,12 +32,11 @@ pub fn validate_server(addr: Ipv4Addr) -> Result<Value, InvalidServerError> {
     receive_status_response(&mut stream).map_err(|err| InvalidServerError(err.message()))
 }
 
-fn receive_status_response(s: &mut TcpStream) -> Result<Value, PacketParseError> {
+fn receive_status_response(s: &mut TcpStream) -> Result<String, PacketParseError> {
     // Skip header
     let _packet_size = MCPacket::read_var_int(s)?;
     let _packet_id = MCPacket::read_var_int(s)?;
 
     let json_str = MCPacket::read_string(s)?;
-    let json: Value = serde_json::from_str(&json_str).map_err(|_| PacketParseError("Error decoding the status JSON message".into()))?;
-    Ok(json)
+    Ok(json_str)
 }

--- a/dispatcher/src/main.rs
+++ b/dispatcher/src/main.rs
@@ -12,11 +12,13 @@ use rocket::serde::{Deserialize, Serialize};
 use routes::scout_routes;
 use crate::ip_chunk_iterator::IpChunkIterator;
 use crate::routes::{client_routes, info_routes};
+use crate::routes::client_routes::ClientJob;
 
 #[derive(Serialize, Deserialize)]
 pub struct ServerState {
     ip_range: Mutex<IpChunkIterator>,
-    valid_ips: Mutex<VecDeque<Ipv4Addr>>
+    valid_ips: Mutex<VecDeque<Ipv4Addr>>,
+    outstanding_client_jobs: Mutex<VecDeque<ClientJob>>
 }
 
 #[rocket::main]
@@ -31,7 +33,8 @@ async fn main() {
         println!("No saved state file found.");
         server_state = ServerState {
             ip_range: Mutex::new(IpChunkIterator::new()),
-            valid_ips: Mutex::new(VecDeque::new())
+            valid_ips: Mutex::new(VecDeque::new()),
+            outstanding_client_jobs: Mutex::new(VecDeque::new())
         };
     }
 
@@ -45,6 +48,12 @@ async fn main() {
 
     println!("Saving current state to disk.");
     let server_state = result.state::<ServerState>().unwrap();
+    // Remove outstanding jobs, add back to queue
+    let mut outstanding = server_state.outstanding_client_jobs.lock().unwrap();
+    let mut valid_ips = server_state.valid_ips.lock().unwrap();
+    outstanding.iter().for_each(|x| valid_ips.push_front(x.ip));
+    outstanding.clear();
+    // Serialize to json, save to file
     let json_state = rocket::serde::json::to_string(server_state)
         .expect("Error serializing server state");
     fs::write("./.dispatcher", json_state).expect("Unable to save state to disk");

--- a/dispatcher/src/routes/client_routes.rs
+++ b/dispatcher/src/routes/client_routes.rs
@@ -1,19 +1,131 @@
+use std::net::{AddrParseError, Ipv4Addr};
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::time::SystemTime;
 use rocket::response::status;
 use rocket::{Route, State};
+use rocket::response::status::BadRequest;
+use rocket::serde::json;
+use rocket::serde::json::{Json, Value};
+use serde::{Deserialize, Serialize, Serializer};
+use serde::ser::SerializeStruct;
 use crate::ServerState;
 
+static JOB_ID: AtomicU32 = AtomicU32::new(0);
+
+#[derive(Deserialize, Copy, Clone)]
+pub struct ClientJob {
+    id: u32,
+    pub ip: Ipv4Addr,
+    creation_time: SystemTime
+}
+
+// Default used when deserializing w/ missing fields
+impl Default for ClientJob {
+    fn default() -> Self {
+        ClientJob {
+            id: 0,
+            ip: Ipv4Addr::new(0, 0, 0, 0),
+            creation_time: SystemTime::now()
+        }
+    }
+}
+
+impl Serialize for ClientJob {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error> where S: Serializer {
+        let mut state = serializer.serialize_struct("ClientJob", 2)?;
+        state.serialize_field("id", &self.id.to_string())?;
+        state.serialize_field("ip", &self.ip.to_string())?;
+        state.end()
+    }
+}
+
 pub fn get_all_routes() -> Vec<Route> {
-    routes![get_job]
+    routes![get_job, post_job]
 }
 
 #[get("/job")]
-fn get_job(state: &State<ServerState>) -> Result<String, status::NotFound<&str>> {
+fn get_job(state: &State<ServerState>) -> Result<Json<ClientJob>, status::NotFound<&str>> {
     let mut valid_ips = state.valid_ips.lock().unwrap();
 
     match valid_ips.pop_front() {
         Some(ip) => {
-            Ok(ip.to_string())
+            let job = ClientJob {
+                id: JOB_ID.fetch_add(1, Ordering::Relaxed),
+                ip,
+                creation_time: SystemTime::now()
+            };
+            // Add job to outstanding list
+            let mut outstanding = state.outstanding_client_jobs.lock().unwrap();
+            outstanding.push_back(job);
+
+            Ok(Json(job))
         },
         None => Err(status::NotFound("No job available"))
     }
+}
+
+/// Body format:
+/// ```json
+/// {
+///   "status": "up",
+///   "ip": "0.0.0.0",
+///   "response": {
+///     ...
+///   }
+/// }
+/// ```
+/// `status` can take a value of `up`, or any other value meaning `down`<br>
+/// `response` is an optional field and does not have to be provided if `status` is not `up`.
+///  Must be included otherwise.
+///
+/// The response format is defined [here](https://wiki.vg/Server_List_Ping#Status_Response).
+/// Useful fields include: `version.name`, `players.online/players.max`, `players.sample[x].name/.id`,
+/// `description`, `favicon` (optional, b64 png format)
+/// `players.sample` is also an optional field, and will be omitted from the response
+/// if there are no online players (`players.online==0`)
+#[post("/job/<id>", data = "<json>")]
+fn post_job(id: u32, json: &str, state: &State<ServerState>) -> Result<status::Accepted<String>, BadRequest<String>> {
+    if json.is_empty() {
+        return Err(BadRequest(Some(String::from("Invalid json data received (empty)"))));
+    }
+
+    // Parse json
+    let json: Value = json::from_str(json).map_err(|e| BadRequest(Some(e.to_string())))?;
+    let status = json["status"].as_str()
+        .ok_or_else(|| BadRequest(Some(String::from("Missing 'status' field"))))?;
+    let ip: Ipv4Addr = json["ip"].as_str()
+        .ok_or_else(|| BadRequest(Some(String::from("Missing `ip` field"))))?
+        .parse().map_err(|e: AddrParseError| BadRequest(Some(e.to_string())))?;
+    let response = json["response"].clone();
+
+    if status.to_lowercase() != "up" {
+        // Remove job from outstanding list (if already in list)
+        let mut outstanding = state.outstanding_client_jobs.lock().unwrap();
+        if let Some(idx) = outstanding.iter().position(|x| x.id == id && x.ip == ip) {
+            outstanding.remove(idx);
+        };
+        return Ok(status::Accepted(None))
+    }
+
+    // Server is up, expect response
+    if response.is_null() {
+        // Empty response when status is up, invalid state
+        return Err(BadRequest(Some(String::from("No response provided when status is  'up'"))));
+    }
+
+    // Get fields
+    let _version = response["version"]["name"].as_str();
+    let _description = response["description"].as_str();
+    let _favicon = response["favicon"].as_str();
+    let _players_connected = response["players"]["online"].as_u64();
+    let _players_max = response["players"]["max"].as_u64();
+    // TODO Implement saving to DB when working on MC-15
+
+    // Remove from outstanding job list
+    let mut outstanding = state.outstanding_client_jobs.lock().unwrap();
+    if let Some(idx) = outstanding.iter().position(|x| x.id == id && x.ip == ip) {
+        outstanding.remove(idx);
+    };
+
+    Ok(status::Accepted(None))
 }

--- a/dispatcher/src/routes/scout_routes.rs
+++ b/dispatcher/src/routes/scout_routes.rs
@@ -38,7 +38,6 @@ pub fn get_all_routes() -> Vec<Route> {
 #[get("/job/<size>")]
 fn get_job(size: usize, state: &State<ServerState>) -> Json<ScoutJob> {
     let mut ip_iterator = state.ip_range.lock().unwrap();
-    // let x: Vec<Ipv4Addr> = ip_iterator.take(size).collect();
     let mut ips: Vec<Ipv4Addr> = Vec::new();
 
     while ips.len() < size {


### PR DESCRIPTION
New client workflow:

1. Ask dispatcher for job, receives a job id with an IP. Dispatcher adds that job to an outstanding job list.
2. Every minute, dispatcher iterates over outstanding jobs and re-adds old jobs to valid ip queue, to be re-dispatched to another client (client took too long to get results).
3. Client tries to connect to potential minecraft server.
4. If connection established, send status response to dispatcher, if no answer, send down status to dispatcher for current job (lets dispatcher know client tried to connected without result, as opposed to client not doing anything, see step 2)