### PR TITLE
MC-21 Restored server state serialization

### DIFF
--- a/dispatcher/src/main.rs
+++ b/dispatcher/src/main.rs
@@ -41,12 +41,29 @@ async fn main() -> io::Result<()> {
     };
 
     env_logger::init();
+    let state_copy = server_state.clone();
     HttpServer::new(move || {
         App::new()
             .wrap(Logger::default())
-            .app_data(server_state.clone())
+            .app_data(state_copy.clone())
             .service(get_client_scope())
             .service(get_scout_scope())
             .service(get_info_scope())
-    }).bind(("0.0.0.0", 8000))?.run().await
+    }).bind(("0.0.0.0", 8000))?.run().await.expect("HttpServer panicked!");
+
+    // Save to server state to disk
+    println!("Saving current state to disk.");
+    // Start by adding outstanding jobs back to valid_ips pool
+    {
+        let mut outstanding = server_state.outstanding_client_jobs.lock().unwrap();
+        let mut valid_ips = server_state.valid_ips.lock().unwrap();
+        outstanding.iter().for_each(|x| valid_ips.push_front(x.ip));
+        outstanding.clear();
+    }
+    // Serialize to json, save to disk
+    let json_val = serde_json::to_string(&server_state.into_inner())
+        .expect("Error serializing server state");
+    fs::write("./.dispatcher", json_val).expect("Unable to save state to disk.");
+    println!("Success! Shutting down...");
+    Ok(())
 }


### PR DESCRIPTION
Feature was mistakenly removed in #9; deserialization was ported over to new framework, but serialization was not, meaning the server would always deserialize the old data and wouldn't overwrite it with up to date data.