### PR TITLE
MC-14 Created error struct constructor

### DIFF
--- a/client/src/checker.rs
+++ b/client/src/checker.rs
@@ -7,6 +7,12 @@ use crate::mc_packet::{MCPacket, PacketParseError};
 #[derive(Debug)]
 pub struct InvalidServerError(String);
 
+impl InvalidServerError {
+    pub fn new(s: &str) -> Self {
+        Self(String::from(s))
+    }
+}
+
 impl Display for InvalidServerError {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(f, "Error occurred when trying to validate server: {}", self.0)
@@ -18,9 +24,9 @@ impl Error for InvalidServerError {}
 pub fn validate_server(addr: Ipv4Addr) -> Result<String, InvalidServerError> {
     let socket_addr = SocketAddr::new(IpAddr::V4(addr), 25565);
     let mut stream = TcpStream::connect_timeout(&socket_addr, Duration::from_secs(crate::TCP_TIMEOUT_SECS))
-        .map_err(|_| InvalidServerError("Timed out connecting to host".into()))?;
+        .map_err(|_| InvalidServerError::new("Timed out connecting to host"))?;
     stream.set_read_timeout(Some(Duration::from_secs(crate::TCP_TIMEOUT_SECS)))
-        .map_err(|_| InvalidServerError("Error when trying to set read timeout".into()))?;
+        .map_err(|_| InvalidServerError::new("Error when trying to set read timeout"))?;
 
     // Initialize MC connection
     MCPacket::status_handshake(&addr.to_string(), 25565).write_to_stream(&mut stream);

--- a/client/src/mc_packet.rs
+++ b/client/src/mc_packet.rs
@@ -13,6 +13,12 @@ impl PacketParseError {
     }
 }
 
+impl PacketParseError {
+    pub fn new(s: &str) -> Self {
+        Self(String::from(s))
+    }
+}
+
 impl Display for PacketParseError {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(f, "Error parsing data: {}", self.0)
@@ -84,7 +90,7 @@ impl MCPacket {
         let mut iter = s.bytes();
 
         loop {
-            let byte = iter.next().ok_or_else(|| PacketParseError("Ran out of bytes trying to read VarInt".into()))?
+            let byte = iter.next().ok_or_else(|| PacketParseError::new("Ran out of bytes trying to read VarInt"))?
                 .map_err(|err| PacketParseError(format!("OS Error reading VarInt: {}", err)))?;
             val |= ((byte & 0b01111111) as u64) << i;
             i += 7;
@@ -98,7 +104,7 @@ impl MCPacket {
     pub fn read_string(s: &mut dyn Read) -> Result<String, PacketParseError> {
         let size = MCPacket::read_var_int(s)?;
         let mut buf = vec![0; size as usize];
-        s.read_exact(buf.as_mut_slice()).map_err(|_| PacketParseError("Error reading string from stream".into()))?;
+        s.read_exact(buf.as_mut_slice()).map_err(|_| PacketParseError::new("Error reading string from stream"))?;
         String::from_utf8(buf).map_err(|err| PacketParseError(format!("Error decoding string: {}", err)))
     }
 


### PR DESCRIPTION
Allows the error struct to be initialized by a `String` (normal syntax), or with a `&str`, through the new constructor which internally casts the `str` to a `String`